### PR TITLE
support for fast-forward merges with a comment of '/fast-forward' on PRs

### DIFF
--- a/.github/workflows/fast_forward.yml
+++ b/.github/workflows/fast_forward.yml
@@ -1,0 +1,22 @@
+# From: https://github.com/marketplace/actions/fast-forward-pr
+# To fix https://stackoverflow.com/questions/60597400/how-to-do-a-fast-forward-merge-on-github
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  fast_forward_job:
+    name: Fast Forward
+    # Comment '/fast-forward' on the PR to do a proper fast-forward merge to preserve tags used for triggering a release.
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/fast-forward')   
+    runs-on: ubuntu-latest
+    steps:
+      # To use this repository's private action, you must check out the repository
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Fast Forward PR
+        uses: endre-spotlab/fast-forward-js-action@2.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          success_message: 'Success! Fast forwarded ***target_base*** to ***source_head***! ```git checkout target_base && git merge source_head --ff-only``` '
+          failure_message: 'Failed! Cannot do fast forward!'


### PR DESCRIPTION
The default behaviour of merges in the github web interface is to make a new commit which means that the tag is not associated with the head of master,
This behaviour is unexpected and wrong and leads to tagged master commits not being released as expected.

Another alternative is to merge manually and push to 'master' github will close the PR as if it had been done through the web interface.