### PR TITLE
fix #15: explain building with local 'pdflatex' or 'docker'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,9 @@ ifneq (, $(shell which pdflatex))
 	pdflatex -interaction=nonstopmode -halt-on-error $<
 else
 	@echo Build using Docker image.
-	docker run --rm -i --user="$(id -u):$(id -g)" --net=none \
+	docker run --rm -i \
+		--user $(id -u ${USER}):$(id -g ${USER}) \
+		--net=none \
 		--read-only \
 		-v $(PWD):/data \
 		blang/latex:ctanbasic \

--- a/README.md
+++ b/README.md
@@ -4,13 +4,26 @@
 
 ### GNU/Linux
 
+#### Using pdflatex
 ```bash
 sudo apt-get install texlive
 wget -O res.cls http://www.ctan.org/tex-archive/macros/latex/contrib/resume/res.cls
 pdflatex aaronrobson-cv.tex
 ```
 
-aka
+#### Using docker
+```bash
+docker run --rm -i \
+    --user $(id -u ${USER}):$(id -g ${USER}) \
+    --net=none \
+    --read-only \
+    -v $(pwd):/data \
+    blang/latex:ctanbasic \
+    pdflatex aaronrobson-cv.tex
+```
+
+#### Automatically
+Use locally installed `pdflatex` if present and if not try `docker`.
 ```bash
 make
 ```


### PR DESCRIPTION
Redoing the user specification on the docker way to work via make and manually more consistently.